### PR TITLE
#161342839 Enable Social Login via Google, Facebook and twitter

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ import dotenv from 'dotenv';
 import swagger from 'swagger-ui-express';
 import swaggerDocument from './swagger';
 import config from './server/config/config';
-import { goodHttpResponse } from './server/utilities/httpResponse';
+import { goodHttpResponse, badHttpResponse } from './server/utilities/httpResponse';
 
 import router from './server/routes/index';
 import cleanStrings from './server/middlewares/cleanStrings';
@@ -28,9 +28,13 @@ app.use('/docs', swagger.serve, swagger.setup(swaggerDocument));
 
 app.use('/api/v1', router);
 
-app.get('*', (request, response) => {
+app.get('/', (request, response) => {
   const welcome = 'Welcome to Authors Haven API Version 1.0';
   return goodHttpResponse(response, 200, welcome);
+});
+app.get('*', (request, response) => {
+  const error = 'I am pretty sure this is not what you are looking for. Please enter a valid route';
+  return badHttpResponse(response, 404, error);
 });
 
 const env = process.env.NODE_ENV || 'development';

--- a/package-lock.json
+++ b/package-lock.json
@@ -2441,6 +2441,12 @@
         "type-detect": "^4.0.0"
       }
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -3286,7 +3292,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
@@ -4356,7 +4362,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -5281,7 +5287,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
@@ -5574,6 +5580,46 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "nock": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.2.tgz",
+      "integrity": "sha512-uWrdlRzG28SXM5yqYsUHfYBRqljF8P6aTRDh6Y5kTgs/Q4GB59QWlpiegmDHQouvmX/rDyKkC/nk+k4nA+QPNw==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "dev": true
+        }
+      }
     },
     "nodemailer": {
       "version": "4.6.8",
@@ -7306,6 +7352,11 @@
         }
       }
     },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -7657,6 +7708,22 @@
         "pause": "0.0.1"
       }
     },
+    "passport-facebook": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/passport-facebook/-/passport-facebook-2.1.1.tgz",
+      "integrity": "sha1-w50LUq5NWRYyRaTiGnubYyEwMxE=",
+      "requires": {
+        "passport-oauth2": "1.x.x"
+      }
+    },
+    "passport-google-oauth20": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-1.0.0.tgz",
+      "integrity": "sha1-O5YOih1w0dvnlGFcgnxoxAOSpdA=",
+      "requires": {
+        "passport-oauth2": "1.x.x"
+      }
+    },
     "passport-local": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
@@ -7665,10 +7732,40 @@
         "passport-strategy": "1.x.x"
       }
     },
+    "passport-oauth1": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth1/-/passport-oauth1-1.1.0.tgz",
+      "integrity": "sha1-p96YiiEfnPRoc3cTDqdN8ycwyRg=",
+      "requires": {
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "utils-merge": "1.x.x"
+      }
+    },
+    "passport-oauth2": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.4.0.tgz",
+      "integrity": "sha1-9i+BWDy+EmCb585vFguTlaJ7hq0=",
+      "requires": {
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      }
+    },
     "passport-strategy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
       "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
+    "passport-twitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/passport-twitter/-/passport-twitter-1.0.4.tgz",
+      "integrity": "sha1-AaeZ4fdgvy3knyul+6MigvGJMtc=",
+      "requires": {
+        "passport-oauth1": "1.x.x",
+        "xtraverse": "0.1.x"
+      }
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -7917,6 +8014,12 @@
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
       }
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
     },
     "proto-list": {
       "version": "1.2.4",
@@ -9564,6 +9667,11 @@
         }
       }
     },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
+    },
     "umzug": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/umzug/-/umzug-2.1.0.tgz",
@@ -9926,6 +10034,11 @@
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
     },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+    },
     "xregexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
@@ -9935,6 +10048,14 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "xtraverse": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xtraverse/-/xtraverse-0.1.0.tgz",
+      "integrity": "sha1-t0G60BjveNip0ug63gB7P3lZxzI=",
+      "requires": {
+        "xmldom": "0.1.x"
+      }
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,13 +32,16 @@
     "morgan": "^1.9.1",
     "nodemailer": "^4.6.8",
     "passport": "^0.4.0",
+    "passport-facebook": "^2.1.1",
+    "passport-google-oauth20": "^1.0.0",
     "passport-local": "^1.0.0",
+    "passport-twitter": "^1.0.4",
     "pg": "^7.5.0",
     "pg-hstore": "^2.3.2",
     "sequelize": "^4.41.0",
+    "sequelize-cli": "^5.2.0",
     "slug": "^0.9.2",
-    "swagger-ui-express": "^4.0.1",
-    "sequelize-cli": "^5.2.0"
+    "swagger-ui-express": "^4.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -60,6 +63,7 @@
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.3.0",
+    "nock": "^10.0.2",
     "nodemon": "^1.18.4",
     "nyc": "^13.1.0"
   }

--- a/server/config/socialConfig.js
+++ b/server/config/socialConfig.js
@@ -1,0 +1,13 @@
+const socialconfig = {
+  facebook: {
+    clientID: process.env.FB_CLIENT_ID,
+    clientSecret: process.env.FB_CLIENT_SECRET,
+    callbackURL: process.env.FB_CLIENT_URL,
+  },
+  google: {
+    clientID: process.env.GOOGLE_CLIENT_ID,
+    clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    callbackURL: process.env.GOOGLE_CLIENT_URL,
+  },
+};
+export default socialconfig;

--- a/server/migrations/20181023192004-create-user.js
+++ b/server/migrations/20181023192004-create-user.js
@@ -9,7 +9,7 @@ export default {
     },
     username: {
       type: Sequelize.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     email: {
       type: Sequelize.STRING,
@@ -18,7 +18,7 @@ export default {
     },
     password: {
       type: Sequelize.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     facebook: {
       type: Sequelize.STRING,
@@ -38,7 +38,7 @@ export default {
     },
     role: {
       type: Sequelize.ENUM('user', 'admin'),
-      allowNull: false,
+      allowNull: true,
     },
     isConfirmed: {
       type: Sequelize.BOOLEAN,

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -3,15 +3,15 @@ export default (sequelize, DataTypes) => {
   const User = sequelize.define('User', {
     firstName: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     lastName: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     username: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     email: {
       type: DataTypes.STRING,
@@ -19,7 +19,7 @@ export default (sequelize, DataTypes) => {
     },
     password: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     facebook: {
       type: DataTypes.STRING,
@@ -39,7 +39,7 @@ export default (sequelize, DataTypes) => {
     },
     role: {
       type: DataTypes.ENUM('user', 'admin'),
-      allowNull: false,
+      allowNull: true,
     },
     isConfirmed: {
       type: DataTypes.BOOLEAN,

--- a/server/repository/userRepository.js
+++ b/server/repository/userRepository.js
@@ -154,6 +154,33 @@ class UserRepository {
   }
 
   /**
+ * finds a user by email, if user exists return the user, if not create one
+ * @param {string} email user Email to search by
+ * @param {string} lastName user lastName to insert in database
+ * @param {string} firstName user firstName to insert in database
+ * @param {string} imageUrl imageUrl to insert in database
+ * @param {string} token  jwt token for user access
+ * @returns {object} The JSON response to the user.
+ */
+  static async findOrCreate(email, lastName, firstName, imageUrl) {
+    const user = await User.findOrCreate({
+      where: {
+        email
+      },
+      defaults: {
+        firstName,
+        lastName,
+        email,
+        imageUrl
+      }
+    })
+      .spread(user => user.get({
+        plain: true
+      }));
+    return user;
+  }
+
+  /**
    * Change confirmEmail field to true
    * @param {integer} userId User Id
    * @returns {object} i dont know yet

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -7,7 +7,7 @@ const router = Router();
 
 router.use(
   userRouter,
-  articleRouter
+  articleRouter,
 );
 
 export default router;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,9 +1,14 @@
 import { Router } from 'express';
+import passport from 'passport';
 import User from '../controllers/user';
+import googleCallback from '../utilities/passportAuthentication';
+
 import inputValidator from '../middlewares/validations';
 import isAuthenticated from '../middlewares/checkAuth';
 import isAuthorized from '../middlewares/authorization';
 import uploadImage from '../middlewares/uploadImage';
+import facebookRoutes from '../services/facebookStrategy';
+import googleRoutes from '../services/googleStrategy';
 
 import validator from '../middlewares/paramChecker';
 
@@ -24,4 +29,19 @@ router.put('/users/:username', isAuthenticated, inputValidator.editProfile, isAu
 router.post('/profiles/:username/follow', isAuthenticated, validator.validateUsername, User.follow);
 router.delete('/profiles/:username/follow', isAuthenticated, validator.validateUsername, User.unfollow);
 
+router.get('/auth/facebook', facebookRoutes.authenticate('facebook'));
+
+router.get('/auth/facebook/callback',
+  passport.authenticate('facebook',
+    {
+      successRedirect: '/',
+      failureRedirect: '/'
+    }));
+
+router.get('/auth/google',
+  googleRoutes.authenticate('google', { scope: 'https://www.google.com/m8/feeds' }));
+
+router.get('/auth/google/callback',
+  passport.authenticate('google', { failureRedirect: '/' }),
+  googleCallback);
 export default router;

--- a/server/services/facebookStrategy.js
+++ b/server/services/facebookStrategy.js
@@ -1,0 +1,22 @@
+import passport from 'passport';
+import {
+  Strategy as FacebookStrategy
+} from 'passport-facebook';
+import dotenv from 'dotenv';
+import socialConfig from '../config/socialConfig';
+import { getUrl } from '../utilities/currentEnv';
+import passportAuthenticator from '../utilities/passportAuthentication';
+import socialCallback from './socialCallback';
+
+dotenv.config();
+
+passport.use(new FacebookStrategy({
+  clientID: socialConfig.facebook.clientID,
+  clientSecret: socialConfig.facebook.clientSecret,
+  callbackURL: `${getUrl}${socialConfig.facebook.callbackURL}`,
+  profileFields: ['id', 'emails', 'name', 'picture.type(large)']
+}, socialCallback));
+
+
+const facebookRoutes = passportAuthenticator('facebook');
+export default facebookRoutes;

--- a/server/services/googleStrategy.js
+++ b/server/services/googleStrategy.js
@@ -1,0 +1,20 @@
+import passport from 'passport';
+import {
+  Strategy as GoogleStrategy
+} from 'passport-google-oauth20';
+import dotenv from 'dotenv';
+import socialConfig from '../config/socialConfig';
+import { getUrl } from '../utilities/currentEnv';
+import passportAuthenticator from '../utilities/passportAuthentication';
+import socialCallback from './socialCallback';
+
+dotenv.config();
+
+passport.use(new GoogleStrategy({
+  clientID: socialConfig.google.clientID,
+  clientSecret: socialConfig.google.clientSecret,
+  callbackURL: `${getUrl}${socialConfig.google.callbackURL}`,
+}, socialCallback));
+
+const googleRoutes = passportAuthenticator('google');
+export default googleRoutes;

--- a/server/services/socialCallback.js
+++ b/server/services/socialCallback.js
@@ -1,0 +1,20 @@
+import userRepo from '../repository/userRepository';
+
+/**
+   * callback function for social login
+   * @param {object} accessToken token from social login
+   * @param  {object} refreshToken token from social login
+   * @param  {object} profile of a user from social login
+   * @param {function} done end of function
+   * @returns {function} callback
+   */
+const socialCallback = (accessToken, refreshToken, profile, done) => {
+  const email = profile.emails[0].value;
+  const { familyName, givenName } = profile.name;
+  const imageUrl = profile.photos[0].value;
+
+  userRepo.findOrCreate(email, familyName, givenName, imageUrl).then(user => user);
+  done();
+};
+
+export default socialCallback;

--- a/server/tests/controllerTests/socialLogin.test.js
+++ b/server/tests/controllerTests/socialLogin.test.js
@@ -1,0 +1,49 @@
+import chai from 'chai';
+import nock from 'nock';
+import socialCallback from '../../services/socialCallback';
+import app from '../../../app';
+
+const { expect } = chai;
+
+const accessToken = 'sometoken';
+const refreshToken = 'sometoken';
+const profile = {
+  emails: [{ value: 'uemailrl' }],
+  name: {
+    familyName: 'some name',
+    givenName: 'some name'
+  },
+  photos: [{ value: 'url' }]
+};
+
+nock('https://www.facebook.com/')
+  .filteringPath(() => '/api/v1/auth/facebook')
+  .get('/api/v1/auth/facebook')
+  .reply(200, 'facebook route called');
+
+nock('https://www.google.com/')
+  .filteringPath(() => '/api/v1/auth/google')
+  .get('/api/v1/auth/google')
+  .reply(200, 'google callback route called', {
+    Location: '/'
+  });
+
+
+describe('facebook strategy', () => {
+  it('should be a function', () => {
+    expect(socialCallback).to.be.a('function');
+  });
+
+  it('should call the facebook route', async () => {
+    const response = await chai.request(app).get('/api/v1/auth/facebook');
+    expect(response).to.have.status(200);
+    expect(response.text).to.be.deep.equal('facebook route called');
+  });
+});
+
+describe('facebook callback function', () => {
+  it('should return undefined', (done) => {
+    const callBackResult = socialCallback(accessToken, refreshToken, profile, done);
+    expect(callBackResult).to.be.equal(undefined);
+  });
+});

--- a/server/tests/repositoryTests/user.test.js
+++ b/server/tests/repositoryTests/user.test.js
@@ -174,3 +174,16 @@ describe('Update user by username', () => {
     expect(result.lastName).to.be.deep.equals(goodUserUpdate.lastName);
   });
 });
+
+describe('find or create', () => {
+  it('should find a user by email or create one', async () => {
+    const user = await userRepo.findOrCreate(priscilla.email, priscilla.firstName,
+      priscilla.lastName, priscilla.username);
+    expect(user).to.be.an('object');
+    expect(user.email).to.be.deep.equals(priscilla.email);
+    expect(user.firstName).to.be.deep.equals(priscilla.firstName);
+    expect(user.lastName).to.be.deep.equals(priscilla.lastName);
+    expect(user.username).to.be.deep.equals(priscilla.username);
+    expect(user.role).to.be.deep.equals('user');
+  });
+});

--- a/server/utilities/passportAuthentication.js
+++ b/server/utilities/passportAuthentication.js
@@ -1,0 +1,29 @@
+import passport from 'passport';
+
+export default (socialMediaName) => {
+  /**
+ * Authenticates the url.
+ * @returns {function} authenticate
+ */
+  const authenticate = () => passport.authenticate(socialMediaName, { scope: ['email'] });
+  /**
+ * Redirects the url to the home page .
+ * @returns {function} callback
+ */
+  const callback = () => passport.authenticate(socialMediaName, { failureRedirect: '/' });
+
+  /**
+   * Regdirects the url to the home page
+   * @param {object} request Request Object
+   * @param {object} response Response Object
+   * @returns {url} redirects to home page
+   */
+  const googleCallback = (request, response) => {
+    response.redirect('/');
+  };
+  return {
+    authenticate,
+    callback,
+    googleCallback
+  };
+};

--- a/swagger.js
+++ b/swagger.js
@@ -402,5 +402,41 @@ export default {
         }
       }
     },
+    '/api/v1/auth/google': {
+      get: {
+        description: 'Auto generated using Swagger Inspector',
+        responses: {
+          200: {
+            description: 'Auto generated using Swagger Inspector',
+            content: {
+              'text/html; charset=utf-8': {
+                schema: {
+                  type: 'string'
+                },
+                examples: { }
+              }
+            }
+          }
+        }
+      }
+    },
+    '/api/v1/auth/facebook': {
+      get: {
+        description: 'Auto generated using Swagger Inspector',
+        responses: {
+          200: {
+            description: 'Auto generated using Swagger Inspector',
+            content: {
+              'application/json; charset=utf-8': {
+                schema: {
+                  type: 'string'
+                },
+                examples: { }
+              }
+            }
+          }
+        }
+      }
+    }
   }
 };


### PR DESCRIPTION
#### What does this PR do?
- Enable Social Login via Google, Facebook and twitter
#### Description of Task to be completed?
- setup the Authors haven app as a project on facebook and google developer websites
- configure facebook and google strategy using passportJs
- set up auth/facebook and auth/google routes to authenticate social media users
#### How should this be manually tested?
- git clone ` https://github.com/andela/haven-ah-backend.git `
- run npm install to install necessary npm packages
- create dot-env file and setup necessary variables for client secret and client key for facebook and google
-  run ` createdb haven-ah `to create the database
-  run ` sequelize:migrate ` to migrate model
-  navigate to the app's home route and also the social media login routes specified in socialLogin.js file
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#161342839](https://www.pivotaltracker.com/story/show/161342839)
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A