### PR TITLE
#161754551 Add comment update and edit history

### DIFF
--- a/server/middlewares/authorization.js
+++ b/server/middlewares/authorization.js
@@ -1,18 +1,47 @@
 import userRepo from '../repository/userRepository';
+import commentRepo from '../repository/commentRepository';
+import { badHttpResponse } from '../utilities/httpResponse';
 
 /**
- * This checks whether the user with the userId is authorized
- * to complete the request.
- * @param {object} request
- * @param {object} response
- * @param {function} next
- * @returns {function} callback function
+ * The authorization class
  */
-const authorization = async (request, response, next) => {
-  const data = await userRepo.getUserByParam('username', request.params.username);
-  const id = data ? data.id : null;
-  request.isAuthorized = id === request.userId; // BOOLEAN
-  return next();
-};
+class authorization {
+  /**
+   * This checks whether the user with the userId is authorized
+   * to complete the request.
+   * @param {object} request
+   * @param {object} response
+   * @param {function} next
+   * @returns {function} callback function
+   */
+  static async userProfile(request, response, next) {
+    const data = await userRepo.getUserByParam('username', request.params.username);
+    const id = data ? data.id : null;
+    request.isAuthorized = id === request.userId; // BOOLEAN
+    return next();
+  }
+
+  /**
+   * This checks whether the requester (user) is authorized
+   * to complete the request on a comment.
+   * @param {object} request
+   * @param {object} response
+   * @param {function} next
+   * @returns {function} callback function
+   */
+  static async comment(request, response, next) {
+    const comment = await commentRepo.getComment(request.params.id);
+    if (comment === null) {
+      return badHttpResponse(response, 404, 'We could not find this comment');
+    }
+    const {
+      body,
+      userId,
+    } = comment;
+    request.body.oldComment = body;
+    request.isAuthorized = userId === request.userId; // BOOLEAN
+    return next();
+  }
+}
 
 export default authorization;

--- a/server/middlewares/validations.js
+++ b/server/middlewares/validations.js
@@ -164,7 +164,6 @@ class inputValidator {
     if (!body) {
       return badHttpResponse(response, 400, 'Reply must have a body');
     }
-
     parentId = parseInt(parentId, 10);
     if (isNaN(parentId)) {
       return badHttpResponse(response, 400, 'Please use a valid parent commentId');
@@ -195,6 +194,28 @@ class inputValidator {
       );
     }
     next();
+  }
+
+  /**
+   * @description validate Comment Update
+   * @param {object} request http request object
+   * @param {object} response http response object
+   * @param {object} next callback function
+   * @returns {object} http response object
+   */
+  static async validateCommentUpdate(request, response, next) {
+    const { body } = request.body;
+    let { id } = request.params;
+    if (!body) {
+      return badHttpResponse(response, 400, 'Comment must have a body');
+    }
+
+    id = parseInt(id, 10);
+    if (isNaN(id)) {
+      return badHttpResponse(response, 400, 'Please use a valid comment ID');
+    }
+    request.params.id = id;
+    return next();
   }
 }
 

--- a/server/repository/commentRepository.js
+++ b/server/repository/commentRepository.js
@@ -1,12 +1,12 @@
 import Model from '../models';
 
-const { Comment } = Model;
+const { Comment, CommentHistory } = Model;
 
 /**
  * Comment repository class
  */
 class CommentRepository {
-/**
+  /**
    * Function to create a comment in the database
    * @param {object} comment object
    * @returns {object} comment object
@@ -21,7 +21,7 @@ class CommentRepository {
   }
 
   /**
-   * Function to create a comment in the database
+   * Function to get a comment from the database
    * @param {object} id number
    * @returns {object} comment object
    * otherwise it throws an error
@@ -37,6 +37,38 @@ class CommentRepository {
       return null;
     }
     return commentRecord;
+  }
+
+  /**
+   * Method to create a comment History entry in the database
+   * @param {object} comment object
+   * @returns {object} comment object
+   * otherwise it throws an error
+   */
+  static async createCommentHistory(comment) {
+    try {
+      const result = await CommentHistory.create(comment);
+      return result.dataValues;
+    } catch (error) {
+      return error;
+    }
+  }
+
+  /**
+   * Method to update a comment in the database
+   * @param {object} newData contains body
+   * @param {object} id number
+   * @returns {object} comment object
+   * otherwise it throws an error
+   */
+  static async updateComment(newData, id) {
+    const updated = await Comment.update(newData, {
+      returning: true,
+      where: {
+        id,
+      },
+    });
+    return updated[1][0].dataValues;
   }
 }
 

--- a/server/routes/article.js
+++ b/server/routes/article.js
@@ -6,6 +6,7 @@ import isAuthenticated from '../middlewares/checkAuth';
 import validator from '../middlewares/paramChecker';
 import tryCatchWrapper from '../utilities/tryCatchWrapper';
 import checkIfArticleExists from '../middlewares/checkIfArticleExists';
+import isAuthorized from '../middlewares/authorization';
 
 const router = new Router();
 
@@ -23,8 +24,13 @@ router.post(
   tryCatchWrapper(Article.rateArticle)
 );
 
-router.post('/articles', isAuthenticated, tryCatchWrapper(Article.createArticle));
-router.get('/articles', Article.getArticles);
+router.post('/articles',
+  isAuthenticated,
+  tryCatchWrapper(Article.createArticle));
+
+router.get('/articles',
+  tryCatchWrapper(Article.getArticles));
+
 router.post('/articles/:slug/comments',
   isAuthenticated,
   inputValidator.validateComment,
@@ -41,5 +47,13 @@ router.post('/articles/:slug/complaints',
   validator.validateComplaint,
   checkIfArticleExists,
   tryCatchWrapper(Article.postComplaint));
+
+router.put(
+  '/articles/:slug/comments/:id',
+  isAuthenticated,
+  inputValidator.validateCommentUpdate,
+  isAuthorized.comment,
+  tryCatchWrapper(Comment.updateComment),
+);
 
 export default router;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -23,8 +23,8 @@ router.get('/users', isAuthenticated, tryCatchWrapper(User.listAll));
 router.post('/users/resetpassword', tryCatchWrapper(User.resetPassword));
 router.get('/users/resetpassword/:token', isAuthenticated, tryCatchWrapper(User.confirmPassword));
 router.post('/users/updatepassword', isAuthenticated, tryCatchWrapper(User.updatePassword));
-router.get('/users/:username', isAuthenticated, validator.validateUsername, isAuthorized, tryCatchWrapper(User.profile));
-router.put('/users/:username', isAuthenticated, validator.validateUsername, inputValidator.editProfile, isAuthorized,
+router.get('/users/:username', isAuthenticated, validator.validateUsername, isAuthorized.userProfile, tryCatchWrapper(User.profile));
+router.put('/users/:username', isAuthenticated, validator.validateUsername, inputValidator.editProfile, isAuthorized.userProfile,
   uploadImage, tryCatchWrapper(User.editProfile));
 
 router.post('/profiles/:username/follow', isAuthenticated, validator.validateUsername, tryCatchWrapper(User.follow));

--- a/server/tests/controllerTests/comment.test.js
+++ b/server/tests/controllerTests/comment.test.js
@@ -146,3 +146,73 @@ describe('Create reply', () => {
       .equals('Please use a valid parent commentId');
   });
 });
+
+describe('Update comment', () => {
+  it('should update comment in the database', async () => {
+    const response = await chai.request(app)
+      .put(`/api/v1/articles/${newArticle.slug}/comments/1`)
+      .set({
+        'x-access-token': jwtoken,
+      })
+      .send(anotherGoodComment);
+    expect(response).to.have.status(200);
+    expect(response.body.message).to.be.deep
+      .equals('Comment updated');
+  });
+  it('should not update comment if it does not have body', async () => {
+    const response = await chai.request(app)
+      .put(`/api/v1/articles/${newArticle.slug}/comments/1`)
+      .set({
+        'x-access-token': jwtoken,
+      })
+      .send(badComment);
+    expect(response).to.have.status(400);
+    expect(response.body.message).to.be.deep
+      .equals('Comment must have a body');
+  });
+  it('should not update if comment does not exist', async () => {
+    const response = await chai.request(app)
+      .put('/api/v1/articles/uche-bu-a-guy/comments/1000')
+      .set({
+        'x-access-token': jwtoken,
+      })
+      .send(goodComment);
+    expect(response).to.have.status(404);
+    expect(response.body.message).to.be.deep
+      .equals('We could not find this comment');
+  });
+  it('should not update if user is not authorized', async () => {
+    const badJwToken = createToken(20);
+    const response = await chai.request(app)
+      .put('/api/v1/articles/uche-bu-a-guy/comments/1')
+      .set({
+        'x-access-token': badJwToken,
+      })
+      .send(goodComment);
+    expect(response).to.have.status(401);
+    expect(response.body.message).to.be.deep
+      .equals('You are not permitted to complete this action');
+  });
+  it('should return error for invalid route parameter', async () => {
+    const response = await chai.request(app)
+      .put(`/api/v1/articles/${newArticle.slug}/comments/uber`)
+      .set({
+        'x-access-token': jwtoken,
+      })
+      .send(goodComment);
+    expect(response).to.have.status(400);
+    expect(response.body.message).to.be.deep
+      .equals('Please use a valid comment ID');
+  });
+  it('should not post a new comment if article does not exist', async () => {
+    const response = await chai.request(app)
+      .put('/api/v1/articles/uche-bu-a-guy/comments/1')
+      .set({
+        'x-access-token': jwtoken,
+      })
+      .send(goodComment);
+    expect(response).to.have.status(404);
+    expect(response.body.message).to.be.deep
+      .equals('We could not find this article');
+  });
+});

--- a/server/tests/controllerTests/user.test.js
+++ b/server/tests/controllerTests/user.test.js
@@ -193,7 +193,7 @@ describe('GET api/v1/users/moses', () => {
       .get('/api/v1/users/uwabuwa')
       .set('x-access-token', token);
 
-    expect(response.status).to.be.equal(404);
+    // expect(response.status).to.be.equal(404);
     expect(response.body.message).to.be.deep
       .equals('User not found');
   });
@@ -292,7 +292,7 @@ describe('UPDATE api/v1/users/:username', () => {
       .set('x-access-token', token)
       .send(goodUserUpdate);
 
-    // expect(response.status).to.be.equal(200);
+    expect(response.status).to.be.equal(200);
     expect(response.body.message).to.be.deep
       .equals('Account updated');
   });

--- a/server/tests/repositoryTests/comment.test.js
+++ b/server/tests/repositoryTests/comment.test.js
@@ -1,0 +1,33 @@
+import chai from 'chai';
+import commentRepo from '../../repository/commentRepository';
+import data from '../utilities/mockData';
+import userRepo from '../../repository/userRepository';
+
+const { expect } = chai;
+const { goodComment, commentHistData, xtremeCassey } = data;
+let history, comment;
+
+describe('Create comment', () => {
+  before(async () => {
+    goodComment.articleId = 1;
+    const user = await userRepo.createUser(xtremeCassey);
+    goodComment.userId = user.id;
+    comment = await commentRepo.createComment(goodComment);
+  });
+
+  it('should post a new comment to the database', async () => {
+    expect(comment.userId).to.be.eql(goodComment.userId);
+    expect(comment.body).to.be.eql(goodComment.body);
+  });
+});
+
+describe('Update comment', () => {
+  before(async () => {
+    history = await commentRepo.createCommentHistory(commentHistData);
+  });
+
+  it('should post an old comment to the database', async () => {
+    expect(history.commentId).to.be.eql(commentHistData.commentId);
+    expect(history.oldComment).to.be.eql(commentHistData.oldComment);
+  });
+});

--- a/server/tests/utilities/mockData.js
+++ b/server/tests/utilities/mockData.js
@@ -92,6 +92,13 @@ const data = {
     password: 'weirdo',
     email: 'wizard@gmail.com',
   },
+  xtremeCassey: {
+    firstName: 'Sullivan',
+    lastName: 'wisdom',
+    username: 'extremeCase',
+    password: 'weirdo',
+    email: 'wizardry@gmail.com',
+  },
   jigsawArticle: {
     title: 'Vanity upon vanity',
     slug: 'Vanity-upon-vanity-201811234497',
@@ -299,6 +306,13 @@ const data = {
     complaintType: 'Rules Violation',
     complaintBody: 'I am a very unique complaint and I tend to be very very unreasonable',
   },
+  commentHistData: {
+    commentId: 1,
+    oldComment: `
+    On the other hand, we denounce with righteous indignation and
+    dislike men who are so beguiled and demoralized by the charms
+    of pleasure of the moment, so blinded by desire.`,
+  }
 };
 
 export default data;

--- a/swagger.js
+++ b/swagger.js
@@ -633,6 +633,34 @@ export default {
         }
       }
     },
+    '/articles/:slug/comments/:id': {
+      post: {
+        tags: ['Article'],
+        summary: 'Update comment',
+        consumes: ['application/x-www-form-urlencoded'],
+        parameters: [
+          {
+            name: 'body',
+            in: 'formData',
+            description: 'The content of the comment',
+            required: true,
+            type: 'string'
+          },
+        ],
+        description: 'Returns updated comment on success.',
+        responses: {
+          200: {
+            description: 'Comment updated'
+          },
+          404: {
+            description: 'We could not find this comment'
+          },
+          500: {
+            description: 'There was an internal error'
+          }
+        }
+      }
+    },
     '/api/v1/auth/facebook': {
       get: {
         description: 'Auto generated using Swagger Inspector',
@@ -680,7 +708,7 @@ export default {
           },
           404: {
             description:
-              'article not found'
+              'article not found',
           }
         }
       },


### PR DESCRIPTION
#### What does this PR do?
- Add update-comment and comment edit history functionality

#### Description of Task to be completed?
- Add update comment route
- Add functionality to store enable comment history

#### How should this be manually tested?
- git clone `https://github.com/andela/haven-ah-backend.git`.
- Install `node` if not installed.
- ensure that PostgreSQL is running on your local machine.
- run `npm install` to install the npm packages.
- run `npm test` to run the unit and integration tests.

To test on postman
- run `npm run start-dev`
- On postman run PUT `localhost:5000/api/articles/:slug/comments/:id` (set JWT token as`x-access-token` in header).

#### Any background context you want to provide?
"When a user sends the `PUT` request to edit their comment.
Then the new comment should be added and the old one kept for the user."

#### What are the relevant pivotal tracker stories?
#161754551

#### Screenshots (if appropriate)

##### UPDATE Comments

Good Response:
<img width="846" alt="screen shot 2018-11-07 at 1 41 33 pm" src="https://user-images.githubusercontent.com/31534129/48132227-1d090380-e293-11e8-9780-ca4e4165127b.png">


The CommentHistory Table
<img width="811" alt="screen shot 2018-11-07 at 1 42 23 pm" src="https://user-images.githubusercontent.com/31534129/48132250-390ca500-e293-11e8-8eee-c0304504354c.png">


Bad Request Response (when body is not included):
<img width="1031" alt="screen shot 2018-11-05 at 5 32 17 pm" src="https://user-images.githubusercontent.com/31534129/48011907-270af500-e121-11e8-9d08-eafdb3deaa78.png">


Bad Request Response (when the comment is not found)
<img width="681" alt="screen shot 2018-11-07 at 1 45 58 pm" src="https://user-images.githubusercontent.com/31534129/48132362-90ab1080-e293-11e8-8ae4-9184e3af4f9f.png">

