### PR TITLE
#161754577 Add get comment edit history feature

### DIFF
--- a/server/controllers/comment.js
+++ b/server/controllers/comment.js
@@ -88,6 +88,35 @@ class Comment {
     const updatedComment = await commentRepo.updateComment(newBody, id);
     return goodHttpResponse(response, 200, 'Comment updated', updatedComment);
   }
+
+  /** Create a new comment
+   * @param {object} request Request Object
+   * @param {object} response Response Object
+   * @returns {object} Comment Object
+   */
+  static async getCommentWithHistory(request, response) {
+    if (!request.isAuthorized) {
+      return badHttpResponse(
+        response,
+        401,
+        'You are not permitted to complete this action',
+      );
+    }
+
+    const { slug, id } = request.params;
+    const article = await articleRepo.getArticleBySlug(slug);
+    if (article === null) {
+      return badHttpResponse(response, 404, 'We could not find this article');
+    }
+
+    const comment = await commentRepo.getCommentWithHistory(id);
+    if (comment.editHistory.length <= 0) {
+      comment.dataValues.editHistory = 'No edit history to show';
+      return goodHttpResponse(response, 200, 'Comment found', comment);
+    }
+
+    return goodHttpResponse(response, 200, 'Comment and edit history found', comment);
+  }
 }
 
 export default Comment;

--- a/server/middlewares/validations.js
+++ b/server/middlewares/validations.js
@@ -217,6 +217,24 @@ class inputValidator {
     request.params.id = id;
     return next();
   }
+
+  /**
+   * @description validate Comment ID
+   * @param {object} request http request object
+   * @param {object} response http response object
+   * @param {object} next callback function
+   * @returns {object} http response object
+   */
+  static async validateCommentParam(request, response, next) {
+    let { id } = request.params;
+
+    id = parseInt(id, 10);
+    if (isNaN(id)) {
+      return badHttpResponse(response, 400, 'Please use a valid comment ID');
+    }
+    request.params.id = id;
+    return next();
+  }
 }
 
 export default inputValidator;

--- a/server/migrations/20181113025401-update-articleid-column.js
+++ b/server/migrations/20181113025401-update-articleid-column.js
@@ -1,0 +1,15 @@
+export default {
+  up: queryInterface => queryInterface.sequelize.query('alter table "Comments" drop constraint "Comments_articleId_fkey"')
+    .then(() => queryInterface.sequelize.query(
+      `alter table "Comments"
+          add constraint "Comments_articleId_fkey" foreign key("articleId") references "Articles" ("id")
+          on delete cascade`
+    )),
+
+  down: queryInterface => queryInterface.sequelize.query('alter table "Comments" drop constraint "Comments_articleId_fkey"')
+    .then(() => queryInterface.sequelize.query(
+      `alter table "Comments"
+          add constraint "Comments_articleId_fkey" foreign key("articleId") references "Articles" ("id")
+          on delete no action`
+    )),
+};

--- a/server/migrations/20181113033834-update-commentid-column.js
+++ b/server/migrations/20181113033834-update-commentid-column.js
@@ -1,0 +1,19 @@
+export default {
+  up: queryInterface => queryInterface.sequelize.query(
+    'alter table "CommentHistories" drop constraint "CommentHistories_commentId_fkey"'
+  )
+    .then(() => queryInterface.sequelize.query(
+      `alter table "CommentHistories"
+          add constraint "CommentHistories_commentId_fkey" foreign key("commentId") references "Comments" ("id")
+          on delete cascade`
+    )),
+
+  down: queryInterface => queryInterface.sequelize.query(
+    'alter table "CommentHistories" drop constraint "CommentHistories_commentId_fkey"'
+  )
+    .then(() => queryInterface.sequelize.query(
+      `alter table "CommentHistories"
+          add constraint "CommentHistories_commentId_fkey" foreign key("commentId") references "Comments" ("id")
+          on delete no action`
+    )),
+};

--- a/server/models/comment.js
+++ b/server/models/comment.js
@@ -41,7 +41,7 @@ export default (sequelize, DataTypes) => {
     });
     Comment.hasMany(models.CommentHistory, {
       as: 'editHistory',
-      foreignKey: 'id',
+      foreignKey: 'commentId',
       useJunctionTable: false,
     });
   };

--- a/server/models/commenthistory.js
+++ b/server/models/commenthistory.js
@@ -12,6 +12,7 @@ export default (sequelize, DataTypes) => {
   CommentHistory.associate = (models) => {
     CommentHistory.belongsTo(models.Comment, {
       foreignKey: 'commentId',
+      useJunctionTable: false,
     });
   };
   return CommentHistory;

--- a/server/repository/commentRepository.js
+++ b/server/repository/commentRepository.js
@@ -63,6 +63,32 @@ class CommentRepository {
     });
     return updated[1][0].dataValues;
   }
+
+  /**
+   * Function to get a comment with the edit history from the database
+   * @param {object} id number
+   * @returns {object} comment object
+   * otherwise it throws an error
+   */
+  static async getCommentWithHistory(id) {
+    const commentRecord = await Comment.findOne({
+      where: {
+        id,
+      },
+      include: [{
+        model: CommentHistory,
+        as: 'editHistory',
+      }],
+      order: [
+        [
+          {
+            model: CommentHistory, as: 'editHistory'
+          }, 'createdAt', 'DESC'
+        ],
+      ],
+    });
+    return commentRecord;
+  }
 }
 
 export default CommentRepository;

--- a/server/routes/article.js
+++ b/server/routes/article.js
@@ -58,6 +58,17 @@ router.put(
   tryCatchWrapper(Comment.updateComment),
 );
 
-router.get('/articles/:slug', validator.validateSlug, tryCatchWrapper(Article.getArticle));
+router.get(
+  '/articles/:slug',
+  validator.validateSlug,
+  tryCatchWrapper(Article.getArticle)
+);
 
+router.get(
+  '/articles/:slug/comments/:id',
+  isAuthenticated,
+  inputValidator.validateCommentParam,
+  isAuthorized.comment,
+  tryCatchWrapper(Comment.getCommentWithHistory),
+);
 export default router;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -23,8 +23,10 @@ router.get('/users', isAuthenticated, tryCatchWrapper(User.listAll));
 router.post('/users/resetpassword', tryCatchWrapper(User.resetPassword));
 router.get('/users/resetpassword/:token', isAuthenticated, tryCatchWrapper(User.confirmPassword));
 router.post('/users/updatepassword', isAuthenticated, tryCatchWrapper(User.updatePassword));
-router.get('/users/:username', isAuthenticated, validator.validateUsername, isAuthorized.userProfile, tryCatchWrapper(User.profile));
-router.put('/users/:username', isAuthenticated, validator.validateUsername, inputValidator.editProfile, isAuthorized.userProfile,
+router.get('/users/:username', isAuthenticated, validator.validateUsername,
+  isAuthorized.userProfile, tryCatchWrapper(User.profile));
+router.put('/users/:username', isAuthenticated, validator.validateUsername,
+  inputValidator.editProfile, isAuthorized.userProfile,
   uploadImage, tryCatchWrapper(User.editProfile));
 
 router.put('/users/opt/notifications/', isAuthenticated, tryCatchWrapper(User.optNotification));

--- a/server/tests/controllerTests/comment.test.js
+++ b/server/tests/controllerTests/comment.test.js
@@ -204,13 +204,82 @@ describe('Update comment', () => {
     expect(response.body.message).to.be.deep
       .equals('Please use a valid comment ID');
   });
-  it('should not post a new comment if article does not exist', async () => {
+  it('should not update comment if article does not exist', async () => {
     const response = await chai.request(app)
       .put('/api/v1/articles/uche-bu-a-guy/comments/1')
       .set({
         'x-access-token': jwtoken,
       })
       .send(goodComment);
+    expect(response).to.have.status(404);
+    expect(response.body.message).to.be.deep
+      .equals('We could not find this article');
+  });
+});
+
+describe('Get comment and edit comment history', () => {
+  it('should get comment from the database and the edit history', async () => {
+    const response = await chai.request(app)
+      .get(`/api/v1/articles/${newArticle.slug}/comments/1`)
+      .set({
+        'x-access-token': jwtoken,
+      });
+    expect(response).to.have.status(200);
+    expect(response.body.message).to.be.deep
+      .equals('Comment and edit history found');
+    expect(response.body.data).to.have.property('editHistory');
+    expect(response.body.data.editHistory).to.be.an('array');
+  });
+  it('should get comment from the database and the edit history', async () => {
+    const response = await chai.request(app)
+      .get(`/api/v1/articles/${newArticle.slug}/comments/2`)
+      .set({
+        'x-access-token': jwtoken,
+      });
+    expect(response).to.have.status(200);
+    expect(response.body.message).to.be.deep
+      .equals('Comment found');
+    expect(response.body.data).to.have.property('editHistory');
+    expect(response.body.data.editHistory).to.be.deep
+      .equals('No edit history to show');
+  });
+  it('should not get comment if comment does not exist', async () => {
+    const response = await chai.request(app)
+      .get(`/api/v1/articles/${newArticle.slug}/comments/1000`)
+      .set({
+        'x-access-token': jwtoken,
+      });
+    expect(response).to.have.status(404);
+    expect(response.body.message).to.be.deep
+      .equals('We could not find this comment');
+  });
+  it('should return error for invalid route parameter', async () => {
+    const response = await chai.request(app)
+      .get(`/api/v1/articles/${newArticle.slug}/comments/uber`)
+      .set({
+        'x-access-token': jwtoken,
+      });
+    expect(response).to.have.status(400);
+    expect(response.body.message).to.be.deep
+      .equals('Please use a valid comment ID');
+  });
+  it('should not show comment history if user is not authorized', async () => {
+    const badJwToken = createToken(20);
+    const response = await chai.request(app)
+      .get(`/api/v1/articles/${newArticle.slug}/comments/1`)
+      .set({
+        'x-access-token': badJwToken,
+      });
+    expect(response).to.have.status(401);
+    expect(response.body.message).to.be.deep
+      .equals('You are not permitted to complete this action');
+  });
+  it('should return error if article does not exist', async () => {
+    const response = await chai.request(app)
+      .get('/api/v1/articles/uche-bu-a-guy/comments/1')
+      .set({
+        'x-access-token': jwtoken,
+      });
     expect(response).to.have.status(404);
     expect(response.body.message).to.be.deep
       .equals('We could not find this article');

--- a/swagger.js
+++ b/swagger.js
@@ -720,7 +720,7 @@ export default {
       }
     },
     '/articles/:slug/comments/:id': {
-      post: {
+      put: {
         tags: ['Article'],
         summary: 'Update comment',
         consumes: ['application/x-www-form-urlencoded'],
@@ -732,11 +732,46 @@ export default {
             required: true,
             type: 'string'
           },
+          {
+            name: 'id',
+            in: 'path',
+            description: 'ID of comment to update',
+            required: true,
+            type: 'integer',
+            format: 'int64'
+          }
         ],
         description: 'Returns updated comment on success.',
         responses: {
           200: {
             description: 'Comment updated'
+          },
+          404: {
+            description: 'We could not find this comment'
+          },
+          500: {
+            description: 'There was an internal error'
+          }
+        }
+      },
+      get: {
+        tags: ['Article'],
+        summary: 'Get comment using id',
+        consumes: ['application/x-www-form-urlencoded'],
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            description: 'ID of comment to return',
+            required: true,
+            type: 'integer',
+            format: 'int64'
+          }
+        ],
+        description: 'Returns updated comment on success.',
+        responses: {
+          200: {
+            description: 'Comment and edit history found'
           },
           404: {
             description: 'We could not find this comment'


### PR DESCRIPTION
#### What does this PR do?
- Add GET comment edit history feature

#### Description of Task to be completed?
- Create the route for getting a comment and its edit history
- Add tests for route
- write documentation
- Update migration for Comments and CommentHistories table

#### How should this be manually tested?
- git clone `https://github.com/andela/haven-ah-backend.git`.
- Install `node` if not installed.
- ensure that PostgreSQL is running on your local machine.
- run `npm install` to install the npm packages.
- run `npm test` to run the unit and integration tests.

To test on postman
- run `npm run start-dev`
- *For Comment,* On postman run GET `localhost:5000/api/articles/:slug/comments/:id` (set JWT token as`x-access-token` in header).

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#161754577

#### Screenshots (if appropriate)

Good Response 1:
<img width="1089" alt="screen shot 2018-11-08 at 2 38 28 pm" src="https://user-images.githubusercontent.com/31534129/48209026-7006b780-e374-11e8-979d-666e9d07c3e6.png">

Good Response 2 (No edit history):
<img width="1111" alt="screen shot 2018-11-08 at 3 00 05 pm" src="https://user-images.githubusercontent.com/31534129/48209057-844ab480-e374-11e8-84d8-122d848943af.png">


Bad Request Response (when a comment is not found):
<img width="681" alt="screen shot 2018-11-07 at 1 45 58 pm" src="https://user-images.githubusercontent.com/31534129/48209074-90367680-e374-11e8-9fca-91f60bd88737.png">
