### PR TITLE
#161877953 Delete an article

### DIFF
--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -150,6 +150,22 @@ class Article {
     });
     return goodHttpResponse(response, 201, 'Article rated', rating);
   }
+
+  /**
+   *
+   * @param {object} request Request Object
+   * @param {object} response Response Object
+   * @returns {object} response
+   */
+  static async deleteArticle(request, response) {
+    const { article, userId } = request;
+    const { userid } = article.dataValues;
+    if (userid === userId || request.role === 'superadmin' || request.role === 'admin') {
+      await articleRepo.deleteArticle(article.dataValues);
+      return goodHttpResponse(response, 202, 'Article deleted');
+    }
+    return goodHttpResponse(response, 401, 'You cannot deleted this article');
+  }
 }
 
 export default Article;

--- a/server/middlewares/checkIfArticleExists.js
+++ b/server/middlewares/checkIfArticleExists.js
@@ -13,7 +13,7 @@ const checkIfArticleExists = async (request, response, next) => {
   const { slug } = request.params;
   const article = await articleRepo.getArticleBySlug(slug);
 
-  if (!article) {
+  if (!article || article.dataValues.isDeleted === true) {
     return badHttpResponse(
       response,
       404,

--- a/server/migrations/20181114124157-update-article-model.js
+++ b/server/migrations/20181114124157-update-article-model.js
@@ -1,0 +1,16 @@
+export default {
+  up: (queryInterface, Sequelize) => {
+    queryInterface.addColumn(
+      'Articles',
+      'isDeleted',
+      {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+      }
+    );
+  },
+
+  down: (queryInterface) => {
+    queryInterface.removeColumn('Articles', 'isDeleted');
+  },
+};

--- a/server/models/articles.js
+++ b/server/models/articles.js
@@ -30,6 +30,10 @@ export default (sequelize, DataTypes) => {
     },
     categoryId: {
       type: DataTypes.INTEGER,
+    },
+    isDeleted: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false
     }
   }, {});
 

--- a/server/repository/articleRepository.js
+++ b/server/repository/articleRepository.js
@@ -29,7 +29,9 @@ class ArticleRepository {
     if (!articleRecord) {
       return null;
     }
-    await articleRecord.destroy();
+    await articleRecord.update({
+      isDeleted: true
+    });
   }
 
   /**

--- a/server/routes/article.js
+++ b/server/routes/article.js
@@ -71,4 +71,12 @@ router.get(
   isAuthorized.comment,
   tryCatchWrapper(Comment.getCommentWithHistory),
 );
+router.delete(
+  '/articles/:slug',
+  isAuthenticated,
+  validator.validateSlug,
+  checkIfArticleExists,
+  tryCatchWrapper(Article.deleteArticle)
+);
+
 export default router;

--- a/server/tests/controllerTests/article.test.js
+++ b/server/tests/controllerTests/article.test.js
@@ -227,4 +227,28 @@ describe('GET api/v1/articles/:slug', () => {
     expect(response.body.data.Author).to.have
       .keys('id', 'firstName', 'lastName', 'username', 'imageUrl', 'bio');
   });
+
+  it('should delete a single article from the database', async () => {
+    const response = await chai.request(app)
+      .delete(`/api/v1/articles/${jigSlug}`)
+      .set({
+        'x-access-token': createToken(5000),
+      });
+
+    expect(response).to.have.status(401);
+    expect(response.body.message).to.be.deep
+      .equals('You cannot deleted this article');
+  });
+
+  it('should delete a single article from the database', async () => {
+    const response = await chai.request(app)
+      .delete(`/api/v1/articles/${jigSlug}`)
+      .set({
+        'x-access-token': jwtoken,
+      });
+
+    expect(response).to.have.status(202);
+    expect(response.body.message).to.be.deep
+      .equals('Article deleted');
+  });
 });

--- a/swagger.js
+++ b/swagger.js
@@ -539,6 +539,35 @@ export default {
         }
       }
     },
+    '/articles/:slug': {
+      delete: {
+        tags: ['Article'],
+        summary: 'Delete an article',
+        consumes: ['application/x-www-form-urlencoded'],
+        parameters: [
+          {
+            name: 'x-access-token',
+            in: 'header',
+            description: 'Authorization token',
+            required: true,
+            type: 'string'
+          }
+        ],
+        description: 'Returns a succes message or an error.',
+        responses: {
+          201: {
+            description:
+              'Article deleted'
+          },
+          401: {
+            description: 'You cannot deleted this article'
+          },
+          500: {
+            description: 'There was an internal error'
+          }
+        }
+      }
+    },
     '/articles/:slug/rating': {
       post: {
         tags: ['Article'],


### PR DESCRIPTION
#### What does this PR do?
Enable users delete articles they create

#### Description of Task to be completed?
- Create a controller to delete articles
- Create route with proper validations
- Write integration tests
- Document endpoints

#### How should this be manually tested?
- Git clone this repository
- Cd into the `haven-ah-backend` folder
- Start up postman and hit the route `localhost:5000/api/v1/articles/:slug` with a `DELETE` request
- To test the entire application, run `npm test`

#### What are the relevant pivotal tracker stories?
[#161877953](https://www.pivotaltracker.com/story/show/161877953)

#### Screenshots (if appropriate)
*Attempting to delete an article you didn't create*
<img width="1216" alt="screen shot 2018-11-13 at 6 44 19 pm" src="https://user-images.githubusercontent.com/41582565/48432285-3bc83800-e774-11e8-8220-5d70669c7703.png">
*Deleting an article with the authorized token*
<img width="1219" alt="screen shot 2018-11-13 at 6 44 33 pm" src="https://user-images.githubusercontent.com/41582565/48432323-58647000-e774-11e8-9242-882591df9f9e.png">
*Attempting to delete a non-existent article*
<img width="1216" alt="screen shot 2018-11-13 at 6 43 43 pm" src="https://user-images.githubusercontent.com/41582565/48432353-69ad7c80-e774-11e8-9b6e-7e05061aba24.png">



