### PR TITLE
#161962908 Retrieve and address users complaints

### DIFF
--- a/server/controllers/complaint.js
+++ b/server/controllers/complaint.js
@@ -1,0 +1,43 @@
+import complaintRepo from '../repository/complaintRepository';
+import { badHttpResponse, goodHttpResponse, paginatedHttpResponse } from '../utilities/httpResponse';
+
+
+/**
+ * Complaints Controller class
+ */
+class Complaints {
+  /**
+   * Get all complaints
+   * @param {object} request Request Object
+   * @param {object} response Response Object
+   * @returns {object} Object
+   */
+  static async getComplaints(request, response) {
+    const limit = parseInt(request.query.limit, 10) || 10;
+    const page = parseInt(request.query.page, 10) || 1;
+
+    const complaints = await complaintRepo.getComplaints(limit, page);
+    if (!complaints.count) {
+      return goodHttpResponse(response, 200, 'No complaints found');
+    }
+    return paginatedHttpResponse(response, 200, 'Complaints retrieved', complaints);
+  }
+
+  /**
+   * A function to reply user complaints
+   * @param {object} request Request Object
+   * @param {object} response Response Object
+   * @returns {object} Object
+   */
+  static async replyComplaints(request, response) {
+    const { reply } = request.body;
+    const { complaintId } = request.params;
+    const complaint = await complaintRepo.replyComplaints(reply, complaintId);
+    if (!complaint) {
+      return badHttpResponse(response, 404, 'Complaint not found');
+    }
+    return goodHttpResponse(response, 200, 'Complaint addressed');
+  }
+}
+
+export default Complaints;

--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -450,55 +450,35 @@ class User {
   }
 
   /**
- * Update a user's role
+   * Get all user followers
    * @param {object} request Request Object
    * @param {object} response Response Object
-   * @returns {object} Success Response if operation is successful
-   * and error response if operation was not successful
+   * @returns {object} Error if operation was unsuccessful or success response
+   * if operation was successful
    */
-  static async updateUserRole(request, response) {
-    const { role, username } = request.body;
-    const actorRole = request.role;
-
-    if (role === 'superadmin' && actorRole !== 'superadmin') {
-      return badHttpResponse(
-        response,
-        403,
-        'Sorry, you do not have the rights to perform this operation.'
-      );
-    }
-    const user = await userRepo.getUserByParam('username', username);
+  static async getUserFollowers(request, response) {
+    const { userId } = request;
+    const user = await userRepo.getUserByParam('id', userId);
     if (!user) {
       return badHttpResponse(
         response,
         404,
-        'The user you are trying to update does not exist'
+        'User not found'
       );
     }
-
-    if (user.role === role) {
+    const Userfollowers = await followerRepo.followers(user);
+    if (!Userfollowers.length) {
       return badHttpResponse(
         response,
-        409,
-        `This user already has the ${role} role.`
+        404,
+        'Followers not found'
       );
     }
-    const updated = await userRepo.updateUser({
-      role
-    }, username);
-    const { id, firstName, lastName } = updated;
-
-    const updatedUser = {
-      id,
-      name: `${firstName} ${lastName}`,
-      role: updated.role
-    };
-
     return goodHttpResponse(
       response,
       200,
-      'Successfully updated user role',
-      { updatedUser }
+      'Followers retrieved',
+      Userfollowers
     );
   }
 

--- a/server/migrations/20181115171611-update-complaint-model.js
+++ b/server/migrations/20181115171611-update-complaint-model.js
@@ -1,0 +1,16 @@
+export default {
+  up: (queryInterface, Sequelize) => {
+    queryInterface.addColumn(
+      'Complaints',
+      'adminAction',
+      {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      }
+    );
+  },
+
+  down: (queryInterface) => {
+    queryInterface.removeColumn('Complaints', 'adminAction');
+  },
+};

--- a/server/models/complaint.js
+++ b/server/models/complaint.js
@@ -17,6 +17,10 @@ export default (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: false
     },
+    adminAction: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    }
   }, {});
 
   Complaint.associate = (models) => {

--- a/server/repository/complaintRepository.js
+++ b/server/repository/complaintRepository.js
@@ -1,0 +1,52 @@
+import Model from '../models';
+import getPaginationMeta from '../utilities/getPaginationMeta';
+
+const {
+  Complaint
+} = Model;
+
+/**
+ * Complaint repository class
+ */
+class ComplaintRepository {
+  /**
+   * Function to get all complaints in the database
+   * @param { integer } limit
+   * @param { integer } page
+   * @returns { object | null }
+   ** otherwise it throws an error
+   */
+  static async getComplaints(limit = 10, page = 1) {
+    const offset = limit * (page - 1);
+    const complaintRecords = await Complaint.findAndCountAll({
+      limit,
+      offset
+    });
+    complaintRecords.meta = getPaginationMeta(limit, page, complaintRecords.count);
+    return complaintRecords;
+  }
+
+  /**
+   * Function to respond to particular complaint
+   * in the database
+   * @param { string } reply
+   * @param { integer } id
+   * @returns { object | null }
+   ** otherwise it throws an error
+   */
+  static async replyComplaints(reply, id) {
+    const complaint = await Complaint.findOne({
+      where: {
+        id
+      }
+    });
+    if (!complaint) {
+      return null;
+    }
+    return complaint.update({
+      adminAction: reply
+    });
+  }
+}
+
+export default ComplaintRepository;

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -1,10 +1,10 @@
 import { Router } from 'express';
 import User from '../controllers/user';
 import isAuthenticated from '../middlewares/checkAuth';
-
 import tryCatchWrapper from '../utilities/tryCatchWrapper';
 import validator from '../middlewares/paramChecker';
 import checkPermissions from '../middlewares/checkPermissions';
+import Complaint from '../controllers/complaint';
 
 const router = new Router();
 
@@ -13,5 +13,15 @@ router.put('/admin/users/roles',
   checkPermissions,
   validator.validateRoleUpdate,
   tryCatchWrapper(User.updateUserRole));
+
+router.get('/admin/users/complaints',
+  isAuthenticated,
+  checkPermissions,
+  tryCatchWrapper(Complaint.getComplaints));
+
+router.put('/admin/users/complaints/:complaintId/reply',
+  isAuthenticated,
+  checkPermissions,
+  tryCatchWrapper(Complaint.replyComplaints));
 
 export default router;

--- a/server/tests/controllerTests/user.test.js
+++ b/server/tests/controllerTests/user.test.js
@@ -565,28 +565,78 @@ describe('GET api/v1/users/articles/read', () => {
   });
 });
 
-describe('PUT api/v1/profiles/user/followers', () => {
-  it('should return error message if user does not exist', async () => {
-    const response = await chai.request(app)
-      .get('/api/v1/profiles/user/followers')
-      .set({
-        'x-access-token': danToken,
-      });
+describe('PUT api/v1/admin/users/roles', () => {
+  let superAdmin;
+  let superToken;
 
-    expect(response).to.have.status(404);
-    expect(response.body.message).to.be.deep
-      .equals('User not found');
+  before(async () => {
+    superAdmin = await userRepo.createUser(superadmin, 'superadmin');
+    superToken = generateToken(superAdmin.id);
   });
-  it('should return error message if followers does not exist for this user', async () => {
+
+  it('should return an error if actor does not have the rights', async () => {
     const response = await chai.request(app)
-      .get('/api/v1/profiles/user/followers')
+      .put('/api/v1/admin/users/roles')
+      .send({
+        role: 'superadmin',
+        username: sull.username
+      })
       .set({
-        'x-access-token': ucheToken,
+        'x-access-token': token,
+      });
+
+    expect(response).to.have.status(403);
+    expect(response.body.message).to.be.deep.equals('Sorry, you do not have the rights to perform this operation.');
+  });
+
+  it('should return an error if user to be updated doesn\'t exist', async () => {
+    const response = await chai.request(app)
+      .put('/api/v1/admin/users/roles')
+      .send({
+        role: 'admin',
+        username: 'tersoo'
+      })
+      .set({
+        'x-access-token': superToken,
       });
 
     expect(response).to.have.status(404);
-    expect(response.body.message).to.be.deep
-      .equals('Followers not found');
+    expect(response.body.message).to.be.deep.equals('The user you are trying to update does not exist');
+  });
+
+  it('should update the user\'s role', async () => {
+    const response = await chai.request(app)
+      .put('/api/v1/admin/users/roles')
+      .send({
+        role: 'admin',
+        username: sull.username
+      })
+      .set({
+        'x-access-token': superToken,
+      });
+
+    expect(response).to.have.status(200);
+    expect(response.body.data).to.have.key('updatedUser');
+    expect(response.body.message).to.be.deep.equals('Successfully updated user role');
+
+    const { updatedUser } = response.body.data;
+    expect(updatedUser.name).to.be.deep.equal(`${sull.firstName} ${sull.lastName}`);
+    expect(updatedUser.role).to.be.deep.equal('admin');
+  });
+
+  it('should return a response if user already has the role', async () => {
+    const response = await chai.request(app)
+      .put('/api/v1/admin/users/roles')
+      .send({
+        role: 'admin',
+        username: sull.username
+      })
+      .set({
+        'x-access-token': superToken,
+      });
+
+    expect(response).to.have.status(409);
+    expect(response.body.message).to.be.deep.equals('This user already has the admin role.');
   });
 });
 

--- a/server/tests/repositoryTests/followUser.test.js
+++ b/server/tests/repositoryTests/followUser.test.js
@@ -6,6 +6,7 @@ import data from '../utilities/mockData';
 import generateToken from '../../utilities/jwtGenerator';
 import app from '../../../app';
 import notificationRepo from '../../repository/notificationRepository';
+import notifiers from '../../services/notifiers';
 
 const {
   theo, sull, priscilla, dummyNotifications
@@ -25,11 +26,11 @@ describe('function to follow a user', async () => {
     expect(newFollower).to.be.an('array');
   });
 
-  it('should turn on sullivans notification statuis', async () => {
+  it('should turn on sullivans notification status', async () => {
     const response = await chai.request(app)
       .put('/api/v1/users/opt/notifications')
       .set({
-        'x-access-token': generateToken(10),
+        'x-access-token': generateToken(13),
       });
     expect(response).to.have.status(200);
     expect(response.body.message).to.be.deep
@@ -63,6 +64,35 @@ describe('function to follow a user', async () => {
 
     expect(existingFollowerError.message).to.be.deep
       .equals('Sorry. You already follow this user');
+  });
+});
+
+describe('Notifiers test:', () => {
+  it('should be a function', async () => {
+    expect(notifiers.articleNotifier).to.be.a('function');
+    expect(notifiers.commentNotifier).to.be.a('function');
+    expect(notifiers.reactionNotifier).to.be.a('function');
+  });
+
+  it('should send notification and return emails of associated users', async () => {
+    const firstMailInformation = await notifiers.articleNotifier(
+      dummyNotifications.newArticle,
+      'dummy message',
+      'dummy title'
+    );
+    const secondMailInformation = await notifiers.commentNotifier(
+      dummyNotifications.newComment,
+      'dummy message',
+      'dummy title'
+    );
+    const thirdMailInformation = await notifiers.reactionNotifier(
+      dummyNotifications.newReaction,
+      'dummy message',
+      'dummy title'
+    );
+    expect(firstMailInformation.accepted.length).to.equal(1);
+    expect(secondMailInformation.accepted.length).to.equal(1);
+    expect(thirdMailInformation.accepted.length).to.equal(1);
   });
 });
 

--- a/server/tests/utilities/mockData.js
+++ b/server/tests/utilities/mockData.js
@@ -470,7 +470,7 @@ const data = {
   dummyNotifications: {
     newComment: {
       userId: 2,
-      articleId: 7,
+      articleId: 9,
       type: 'NEW_COMMENT_UPDATE',
       content: 'A new comment has been posted'
     },
@@ -482,7 +482,7 @@ const data = {
     },
     newReaction: {
       userId: 2,
-      articleId: 7,
+      articleId: 9,
       type: 'NEW_REACTION_UPDATE',
       content: 'A user reacted on an article you currently follow'
     },

--- a/swagger.js
+++ b/swagger.js
@@ -1097,6 +1097,58 @@ export default {
         }
       },
     },
+    '/admin/users/complaints': {
+      get: {
+        tags: ['Complaints Admin'],
+        summary: 'Get complaints',
+        consumes: ['application/x-www-form-urlencoded'],
+        parameters: [
+          {
+            name: 'x-access-token',
+            in: 'header',
+            description: 'Authorization token',
+            required: true,
+            type: 'string'
+          }
+        ],
+        responses: {
+          200: {
+            description: 'Complaints retrieved'
+          }
+        }
+      },
+    },
+    '/admin/users/complaints/:complaintId/reply': {
+      put: {
+        tags: ['Complaints Admin'],
+        summary: 'Reply complaints',
+        consumes: ['application/x-www-form-urlencoded'],
+        parameters: [
+          {
+            name: 'x-access-token',
+            in: 'header',
+            description: 'Authorization token',
+            required: true,
+            type: 'string'
+          },
+          {
+            name: 'reply',
+            in: 'formData',
+            description: 'Response to complaints',
+            required: true,
+            type: 'string'
+          }
+        ],
+        responses: {
+          200: {
+            description: 'Complaint addressed'
+          },
+          404: {
+            description: 'Complaint not found'
+          }
+        }
+      },
+    },
   },
   components: {
     schemas: {


### PR DESCRIPTION
#### What does this PR do?
Retrieve all complaints and addresses complaints

#### Description of Task to be completed?
- Create a column on the the complaints table for admin response
- Create routes to handle admin requests
- Write integration tests
- Document endpoints

#### How should this be manually tested?
- Git clone this repository
- Cd into the `haven-ah-backend` folder
- Run `npm run start-dev` to start the dev server
- Start up postman and hit the route `localhost:5000/api/v1/admin/users/complaints` with a `GET` request,
- To reply to a complaint hit the route `localhost:5000/api/v1/admin/users/complaints/:id/reply` with a `PUT` request
- To run the integration tests, run `npm test`

#### What are the relevant pivotal tracker stories?
[#161962908](https://www.pivotaltracker.com/story/show/161962908)

#### Screenshots (if appropriate)
<img width="1213" alt="screen shot 2018-11-16 at 8 56 17 am" src="https://user-images.githubusercontent.com/41582565/48614758-50cce300-e98f-11e8-881e-c67e7594c6dd.png">
<img width="1216" alt="screen shot 2018-11-16 at 9 02 15 am" src="https://user-images.githubusercontent.com/41582565/48614762-53c7d380-e98f-11e8-95d3-c5bf062ba0f3.png">

