### PR TITLE
#162047805 Include tags when returning the article

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test": "NODE_ENV=test nyc --reporter=text --reporter=lcov mocha server/tests/**/*.test.js --timeout 100000 --exit",
     "db-migrate": "sequelize db:migrate",
     "db-migrate:undo": "sequelize db:migrate:undo:all",
-    "db-seed": "sequelize db:seed:all"
+    "db-seed": "sequelize db:seed:all",
+    "db-setup": "npm run db-migrate:undo && npm run db-migrate && npm run db-seed"
   },
   "author": "Andela Simulations Programme",
   "license": "MIT",

--- a/server/models/articles.js
+++ b/server/models/articles.js
@@ -54,7 +54,7 @@ export default (sequelize, DataTypes) => {
     Articles.belongsToMany(models.Tags, {
       as: 'Tags',
       through: 'ArticleTag',
-      foreignKey: 'id'
+      foreignKey: 'articleId'
     });
 
     Articles.hasMany(models.Complaint, {

--- a/server/models/tags.js
+++ b/server/models/tags.js
@@ -9,7 +9,7 @@ export default(sequelize, DataTypes) => {
     Tags.belongsToMany(models.Articles, {
       as: 'Articles',
       through: 'ArticleTag',
-      foreignKey: 'id'
+      foreignKey: 'tagId'
     });
   };
   return Tags;

--- a/server/repository/articleRepository.js
+++ b/server/repository/articleRepository.js
@@ -101,18 +101,26 @@ class ArticleRepository {
   static async getSingleArticle(slug) {
     const article = await Articles.findOne({
       where: { slug },
+      attributes: {
+        exclude: ['userid']
+      },
       include: [{
         association: 'Author',
         attributes: ['id', 'firstName', 'lastName', 'username', 'imageUrl', 'bio']
-      }],
-      attributes: {
-        exclude: ['userid']
-      }
+      },
+      ],
     });
 
     if (!article) {
       return null;
     }
+
+    const tags = await article.getTags({
+      attributes: ['tagName'],
+      joinTableAttributes: [],
+    }).map(tag => tag.tagName);
+
+    article.dataValues.tags = tags;
     return article;
   }
 


### PR DESCRIPTION
#### What does this PR do?
Update endpoint to get a single article to return article tags.

#### Description of Task to be completed
- update repository function to include article tags.

#### How should this be manually tested?
- on the terminal run `git clone https://github.com/andela/haven-ah-backend.git`.
- run `git checkout bg-fix-get-article-162047805`.
- ensure that PostgreSQL is running on your local machine.
- set up databases (test and development) following the `.env.sample` file.
- run `npm install` to install the npm packages.
To test on postman

- run `npm run start-dev` and open up postman.

Send **GET** request to ` /api/v1/articles/:slug`.

#### Screenshots if applicable
<img width="1100" alt="screen shot 2018-11-19 at 1 28 10 pm" src="https://user-images.githubusercontent.com/29674347/48709858-02297e00-ec07-11e8-9e50-e24d3ee4ccac.png">


#### What are the relevant Pivotal Tracker stories?
#162047805